### PR TITLE
fix to add pool members with the specific port and to the virtual listener IP address after the creation process

### DIFF
--- a/vendor/ddcloud/resource_vip_pool_member.go
+++ b/vendor/ddcloud/resource_vip_pool_member.go
@@ -45,10 +45,9 @@ func resourceVIPPoolMember() *schema.Resource {
 				Computed: true,
 			},
 			resourceKeyVIPPoolMemberPort: &schema.Schema{
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
-				Default:  "ANY",
 			},
 			resourceKeyVIPPoolMemberStatus: &schema.Schema{
 				Type:         schema.TypeString,

--- a/vendor/ddcloud/resource_virtual_listener.go
+++ b/vendor/ddcloud/resource_virtual_listener.go
@@ -70,6 +70,7 @@ func resourceVirtualListener() *schema.Resource {
 			resourceKeyVirtualListenerIPv4Address: &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				Default:  nil,
 			},
 			resourceKeyVirtualListenerPort: &schema.Schema{
@@ -226,6 +227,7 @@ func resourceVirtualListenerCreate(data *schema.ResourceData, provider interface
 		return fmt.Errorf("Cannot find newly-created virtual listener with Id '%s'.", virtualListenerID)
 	}
 
+	data.Set(resourceKeyVirtualListenerIPv4Address, virtualListener.ListenerIPAddress)
 	// TODO: Populate computed properties.
 
 	return nil
@@ -275,6 +277,7 @@ func resourceVirtualListenerRead(data *schema.ResourceData, provider interface{}
 	data.Set(resourceKeyVirtualListenerConnectionRateLimit, virtualListener.ConnectionRateLimit)
 	data.Set(resourceKeyVirtualListenerSourcePortPreservation, virtualListener.SourcePortPreservation)
 	data.Set(resourceKeyVirtualListenerPersistenceProfileName, virtualListener.PersistenceProfile.Name)
+	data.Set(resourceKeyVirtualListenerIPv4Address, virtualListener.ListenerIPAddress)
 
 	propertyHelper := propertyHelper(data)
 	propertyHelper.SetVirtualListenerIRules(virtualListener.IRules)


### PR DESCRIPTION
fix to add pool members with the specific port and to the virtual listener IP address after the creation process

Previously when we add the pool members with the port number, it ignores the port number and always sets as default value 'ANY'. As per the API, we don't have pass any value for the port if it needs to be 'ANY'.

Changed the virtual_lisetener resource to set the virtual listener IP address once it has been created so that we can use it any other resources
