### PR TITLE
fixed resorce_server poweroff method

### DIFF
--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -847,11 +847,11 @@ func serverPowerOff(providerState *providerState, serverID string) error {
 		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
 		defer asyncLock.Release()
 
-		shutdownError := apiClient.ShutdownServer(serverID)
-		if compute.IsResourceBusyError(shutdownError) {
+		powerOffError := apiClient.PowerOffServer(serverID)
+		if compute.IsResourceBusyError(powerOffError) {
 			context.Retry()
-		} else if shutdownError != nil {
-			context.Fail(shutdownError)
+		} else if powerOffError != nil {
+			context.Fail(powerOffError)
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
Just a quick fix on the server resource where the resource power off method is calling the api shutdown method.

When terraform removes the resource, shutdown takes longer than poweroff.