### PR TITLE
Added a more robust validateAdminPassword function

### DIFF
--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -918,7 +918,7 @@ func validateAdminPassword(adminPassword string, image compute.Image) error {
 	case compute.ImageTypeOS:
 		// Admin password is always mandatory for OS images.
 		if !validPassword {
-			return fmt.Errorf("password does not meet complexity requirements. Needs 9 characters, 1 upper, 1 lower, 1 number and a special char")
+			return fmt.Errorf("A password is mandatory for OS images. Either you have not supplied a password, or the password does not meet complexity requirements. Needs at least 9 characters, 1 upper, 1 lower, 1 number and a special char")
 		}
 
 	case compute.ImageTypeCustomer:
@@ -934,22 +934,20 @@ func validateAdminPassword(adminPassword string, image compute.Image) error {
 			return nil
 		}
 
-		if !validPassword {
-			// Mandatory for Windows Server 2008.
-			if strings.HasPrefix(imageOS.ID, "WIN2008") {
+		// Mandatory for Windows Server 2008.
+		if strings.HasPrefix(imageOS.ID, "WIN2008") && !validPassword {
 
-				return fmt.Errorf("Must specify an initial admin password when deploying a customer image for Windows Server 2008")
-			}
+			return fmt.Errorf("Must specify an initial admin password when deploying a customer image for Windows Server 2008")
+		}
 
-			// Mandatory for Windows Server 2012 R2.
-			if strings.HasPrefix(imageOS.ID, "WIN2012R2") {
-				return fmt.Errorf("Must specify an initial admin password when deploying a customer image for Windows Server 2012 R2")
-			}
+		// Mandatory for Windows Server 2012 R2.
+		if strings.HasPrefix(imageOS.ID, "WIN2012R2") && !validPassword {
+			return fmt.Errorf("Must specify an initial admin password when deploying a customer image for Windows Server 2012 R2")
+		}
 
-			// Mandatory for Windows Server 2012.
-			if strings.HasPrefix(imageOS.ID, "WIN2012") {
-				return fmt.Errorf("Must specify an initial admin password when deploying a customer image for Windows Server 2012")
-			}
+		// Mandatory for Windows Server 2012.
+		if strings.HasPrefix(imageOS.ID, "WIN2012") && !validPassword {
+			return fmt.Errorf("Must specify an initial admin password when deploying a customer image for Windows Server 2012")
 		}
 
 	default:


### PR DESCRIPTION
Modified the validateAdminPassword function in the server resource to not check the strength of the admin password passed to the instance. This now checks for at least 9 letters with the following makeup:
At least one number
At least one special character
At least one upper case character

I chose these values to match the validation performed by the CloudControl UI - happy to modify.

