### PR TITLE
Implement Server resource power state

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto
+
 Makefile linguist-vendored

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ We'd like to thank the following people for their contributions to the ddcloud p
 * William Ninobla ([@wninobla](https://github.com/wninobla))
 * Ming Sheng ([@mingsheng36](https://github.com/mingsheng36))
 * Nigel Wright ([@nwright-nz](https://github.com/nwright-nz))
+* Paul Denning ([@pdenning](https://github.com/pdenning))

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -502,16 +502,16 @@ func resourceServerUpdate(data *schema.ResourceData, provider interface{}) error
 		powerState := propertyHelper.GetOptionalString(resourceKeyServerPowerState, false)
 
 		switch strings.ToLower(*powerState) {
-			case "start":
-				err = serverStart(providerState, serverID)
-			case "shutdown":
-				err = serverShutdown(providerState, serverID)
-			case "off":
-				err = serverPowerOff(providerState, serverID)
-			default:
-				err = fmt.Errorf("Invalid power State (%s); Valid Power states are start, shutdown, off", *powerState)
+		case "start":
+			err = serverStart(providerState, serverID)
+		case "shutdown":
+			err = serverShutdown(providerState, serverID)
+		case "off":
+			err = serverPowerOff(providerState, serverID)
+		default:
+			err = fmt.Errorf("Invalid power State (%s); Valid Power states are start, shutdown, off", *powerState)
 		}
-		
+
 		if err != nil {
 			return err
 		}
@@ -623,6 +623,12 @@ func resourceServerImport(data *schema.ResourceData, provider interface{}) (impo
 	propertyHelper(data).SetDisks(
 		models.NewDisksFromVirtualMachineSCSIControllers(server.SCSIControllers),
 	)
+
+	if server.Started {
+		data.Set(resourceKeyServerPowerState, "start")
+	} else {
+		data.Set(resourceKeyServerPowerState, "Stop")
+	}
 
 	importedData = []*schema.ResourceData{data}
 

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -241,7 +241,7 @@ func resourceServer() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "Should the server be started automatically once it has been deployed",
-				Removed:     fmt.Sprintf("This propery as been removed; set %s to start instead", resourceKeyServerPowerState)
+				Removed:     fmt.Sprintf("This propery as been removed; set %s to start instead", resourceKeyServerPowerState),
 			},			
 		},
 		MigrateState: resourceServerMigrateState,
@@ -499,9 +499,9 @@ func resourceServerUpdate(data *schema.ResourceData, provider interface{}) error
 
 	if data.HasChange(resourceKeyServerPowerState) {
 		log.Printf("Server power state change has been detected.")
-		if strings.ToLower(resourceKeyServerPowerState) := "start" {
+		if strings.ToLower(resourceKeyServerPowerState) == "start" {
 			err = serverStart(providerState, serverID)
-		} else if strings.ToLower(resourceKeyServerPowerState) := "shutdown" {
+		} else if strings.ToLower(resourceKeyServerPowerState) == "shutdown" {
 			err = serverShutdown(providerState, serverID)
 		} else
 		{
@@ -648,9 +648,9 @@ func deployCustomizedServer(data *schema.ResourceData, providerState *providerSt
 	)
 
 	powerOn := false
-	if strings.ToLower(powerState) := "start" {
+	if strings.ToLower(powerState) == "start" {
 		powerOn := true
-	} else if autoStart && strings.ToLower(powerState) := "shutdown" {
+	} else if autoStart && strings.ToLower(powerState) == "shutdown" {
 		// used for backwards compatabiliy with auto_start
 		powerOn := true
 	}
@@ -810,9 +810,9 @@ func deployUncustomizedServer(data *schema.ResourceData, providerState *provider
 		image.GetID(),
 	)
 	powerOn := false
-	if strings.ToLower(powerState) := "start" {
+	if strings.ToLower(powerState) == "start" {
 		powerOn := true
-	} else if autoStart && strings.ToLower(powerState) := "shutdown" {
+	} else if autoStart && strings.ToLower(powerState) == "shutdown" {
 		// used for backwards compatabiliy with auto_start
 		powerOn := true
 	}

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -194,7 +194,7 @@ func resourceServer() *schema.Resource {
 			resourceKeyServerPowerState: &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "shutdown",
+				Default:     "off",
 				Description: "Start or shutdown a server. If set to start upon server creation it will Auto Start the server",
 			},
 
@@ -499,15 +499,19 @@ func resourceServerUpdate(data *schema.ResourceData, provider interface{}) error
 
 	if data.HasChange(resourceKeyServerPowerState) {
 		log.Printf("Server power state change has been detected.")
-		powerState := propertyHelper(resourceKeyServerPowerState, false)
-		if strings.ToLower(powerState) == "start" {
-			err = serverStart(providerState, serverID)
-		} else if strings.ToLower(powerState) == "shutdown" {
-			err = serverShutdown(providerState, serverID)
-		} else {
-			err = fmt.Errorf("arg: invalid power state %g; use either start or shutdown", powerState)
-			//err = errors.new("arg: invalid state; use start or shutdown only")
+		powerState := propertyHelper.GetOptionalString(resourceKeyServerPowerState, false)
+
+		switch strings.ToLower(*powerState) {
+			case "start":
+				err = serverStart(providerState, serverID)
+			case "shutdown":
+				err = serverShutdown(providerState, serverID)
+			case "off":
+				err = serverPowerOff(providerState, serverID)
+			default:
+				err = fmt.Errorf("Invalid power State (%s); Valid Power states are start, shutdown, off", *powerState)
 		}
+		
 		if err != nil {
 			return err
 		}

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -53,7 +53,7 @@ const (
 
 func resourceServer() *schema.Resource {
 	return &schema.Resource{
-		SchemaVersion: 4,
+		SchemaVersion: 5,
 		Create:        resourceServerCreate,
 		Read:          resourceServerRead,
 		Update:        resourceServerUpdate,
@@ -196,7 +196,7 @@ func resourceServer() *schema.Resource {
 			resourceKeyServerPowerState: &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "off",
+				Default:      "disabled",
 				Description:  "Start or shutdown a server. If set to start upon server creation it will Auto Start the server",
 				ValidateFunc: validators.StringIsOneOf("Server Power State", "disabled", "autostart", "start", "shutdown", "shutdown-hard"),
 			},
@@ -250,7 +250,7 @@ func resourceServer() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "Should the server be started automatically once it has been deployed",
-				Removed:     fmt.Sprintf("This propery as been removed; set %s to start instead", resourceKeyServerPowerState),
+				Removed:     fmt.Sprintf("This propery as been removed; set %s to autostart instead", resourceKeyServerPowerState),
 			},
 		},
 		MigrateState: resourceServerMigrateState,

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DimensionDataResearch/dd-cloud-compute-terraform/models"
 	"github.com/DimensionDataResearch/dd-cloud-compute-terraform/retry"
+	"github.com/DimensionDataResearch/dd-cloud-compute-terraform/validators"	
 	"github.com/DimensionDataResearch/go-dd-cloud-compute/compute"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -196,6 +197,7 @@ func resourceServer() *schema.Resource {
 				Optional:    true,
 				Default:     "off",
 				Description: "Start or shutdown a server. If set to start upon server creation it will Auto Start the server",
+                ValidateFunc: validators.StringIsOneOf("Server Power State", "start","off","shutdown"),
 			},
 
 			resourceKeyServerTag: schemaServerTag(),

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -499,13 +499,13 @@ func resourceServerUpdate(data *schema.ResourceData, provider interface{}) error
 
 	if data.HasChange(resourceKeyServerPowerState) {
 		log.Printf("Server power state change has been detected.")
-		powerState := data.Get(resourceKeyServerPowerState).(string)
+		powerState := propertyHelper(resourceKeyServerPowerState,false)
 		if strings.ToLower(powerState) == "start" {
 			err = serverStart(providerState, serverID)
 		} else if strings.ToLower(powerState) == "shutdown" {
 			err = serverShutdown(providerState, serverID)
 		} else {
-			err = fmt.Errorf("arg: invalid state; use either start or shutdown")
+			err = fmt.Errorf("arg: invalid power state %g; use either start or shutdown", powerState)
 			//err = errors.new("arg: invalid state; use start or shutdown only")
 		}
 		if err != nil {

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -191,7 +191,7 @@ func resourceServer() *schema.Resource {
 				Default:     "",
 				Description: "The IP address of the server's secondary DNS server",
 			},
-			resourceKeyServerAutoStart: &schema.Schema{
+			resourceKeyServerPowerState: &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "shutdown",

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -656,9 +656,9 @@ func resourceServerImport(data *schema.ResourceData, provider interface{}) (impo
 	)
 
 	if server.Started {
-		data.Set(resourceKeyServerPowerState, "start")
+		data.Set(resourceKeyServerStarted, true)
 	} else {
-		data.Set(resourceKeyServerPowerState, "Stop")
+		data.Set(resourceKeyServerStarted, false)
 	}
 
 	importedData = []*schema.ResourceData{data}

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -41,7 +41,7 @@ const (
 	resourceKeyServerCustomerImageID    = "customer_image_id"
 	resourceKeyServerCustomerImageName  = "customer_image_name"
 	resourceKeyServerPrimaryAdapterType = "primary_adapter_type"
-	resourceKeyServerAutoStart            = "auto_start"
+	resourceKeyServerAutoStart          = "auto_start"
 
 	resourceCreateTimeoutServer = 30 * time.Minute
 	resourceUpdateTimeoutServer = 10 * time.Minute
@@ -196,7 +196,7 @@ func resourceServer() *schema.Resource {
 				Optional:    true,
 				Default:     "shutdown",
 				Description: "Start or shutdown a server. If set to start upon server creation it will Auto Start the server",
-			},			
+			},
 
 			resourceKeyServerTag: schemaServerTag(),
 
@@ -242,7 +242,7 @@ func resourceServer() *schema.Resource {
 				Default:     false,
 				Description: "Should the server be started automatically once it has been deployed",
 				Removed:     fmt.Sprintf("This propery as been removed; set %s to start instead", resourceKeyServerPowerState),
-			},			
+			},
 		},
 		MigrateState: resourceServerMigrateState,
 	}
@@ -499,18 +499,19 @@ func resourceServerUpdate(data *schema.ResourceData, provider interface{}) error
 
 	if data.HasChange(resourceKeyServerPowerState) {
 		log.Printf("Server power state change has been detected.")
-		if strings.ToLower(resourceKeyServerPowerState) == "start" {
+		powerState := data.Get(resourceKeyServerPowerState).(string)
+		if strings.ToLower(powerState) == "start" {
 			err = serverStart(providerState, serverID)
-		} else if strings.ToLower(resourceKeyServerPowerState) == "shutdown" {
+		} else if strings.ToLower(powerState) == "shutdown" {
 			err = serverShutdown(providerState, serverID)
-		} else
-		{
-			err = errors.new("arg: invalid state; use start or shutdown only")
+		} else {
+			err = fmt.Errorf("arg: invalid state; use either start or shutdown")
+			//err = errors.new("arg: invalid state; use start or shutdown only")
 		}
 		if err != nil {
 			return err
 		}
-		
+
 		data.SetPartial(resourceKeyServerPowerState)
 	}
 
@@ -649,10 +650,10 @@ func deployCustomizedServer(data *schema.ResourceData, providerState *providerSt
 
 	powerOn := false
 	if strings.ToLower(powerState) == "start" {
-		powerOn := true
+		powerOn = true
 	} else if autoStart && strings.ToLower(powerState) == "shutdown" {
 		// used for backwards compatabiliy with auto_start
-		powerOn := true
+		powerOn = true
 	}
 
 	deploymentConfiguration := compute.ServerDeploymentConfiguration{
@@ -797,7 +798,7 @@ func deployUncustomizedServer(data *schema.ResourceData, providerState *provider
 	name := data.Get(resourceKeyServerName).(string)
 	description := data.Get(resourceKeyServerDescription).(string)
 	autoStart := data.Get(resourceKeyServerAutoStart).(bool)
-	powerState := data.Get(resourceKeyServerPowerState).(string)	
+	powerState := data.Get(resourceKeyServerPowerState).(string)
 
 	dataCenterID := networkDomain.DatacenterID
 	log.Printf("Server will be deployed in data centre '%s' with guest OS customisation.", dataCenterID)
@@ -811,10 +812,10 @@ func deployUncustomizedServer(data *schema.ResourceData, providerState *provider
 	)
 	powerOn := false
 	if strings.ToLower(powerState) == "start" {
-		powerOn := true
+		powerOn = true
 	} else if autoStart && strings.ToLower(powerState) == "shutdown" {
 		// used for backwards compatabiliy with auto_start
-		powerOn := true
+		powerOn = true
 	}
 
 	deploymentConfiguration := compute.UncustomizedServerDeploymentConfiguration{

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -499,7 +499,7 @@ func resourceServerUpdate(data *schema.ResourceData, provider interface{}) error
 
 	if data.HasChange(resourceKeyServerPowerState) {
 		log.Printf("Server power state change has been detected.")
-		powerState := propertyHelper(resourceKeyServerPowerState,false)
+		powerState := propertyHelper(resourceKeyServerPowerState, false)
 		if strings.ToLower(powerState) == "start" {
 			err = serverStart(providerState, serverID)
 		} else if strings.ToLower(powerState) == "shutdown" {

--- a/ddcloud/resource_server.go
+++ b/ddcloud/resource_server.go
@@ -499,26 +499,29 @@ func resourceServerUpdate(data *schema.ResourceData, provider interface{}) error
 		}
 	}
 
+
 	if data.HasChange(resourceKeyServerPowerState) {
 		log.Printf("Server power state change has been detected.")
 		powerState := propertyHelper.GetOptionalString(resourceKeyServerPowerState, false)
 
-		switch strings.ToLower(*powerState) {
-		case "start":
-			err = serverStart(providerState, serverID)
-		case "shutdown":
-			err = serverShutdown(providerState, serverID)
-		case "off":
-			err = serverPowerOff(providerState, serverID)
-		default:
-			err = fmt.Errorf("Invalid power State (%s); Valid Power states are start, shutdown, off", *powerState)
-		}
+		if powerState != nil {
+			switch strings.ToLower(*powerState) {
+			case "start":
+				err = serverStart(providerState, serverID)
+			case "shutdown":
+				err = serverShutdown(providerState, serverID)
+			case "off":
+				err = serverPowerOff(providerState, serverID)
+			default:
+				err = fmt.Errorf("Invalid power State (%s); Valid Power states are start, shutdown, off", *powerState)
+			}
 
-		if err != nil {
-			return err
-		}
+			if err != nil {
+				return err
+			}
 
-		data.SetPartial(resourceKeyServerPowerState)
+			data.SetPartial(resourceKeyServerPowerState)
+	    }
 	}
 
 	data.Partial(false)

--- a/ddcloud/resource_server_migrate.go
+++ b/ddcloud/resource_server_migrate.go
@@ -20,7 +20,7 @@ func resourceServerMigrateState(schemaVersion int, instanceState *terraform.Inst
 		return
 	}
 
-	const currentSchemaVersion = 3
+	const currentSchemaVersion = 5
 	for schemaVersion < currentSchemaVersion {
 		switch schemaVersion {
 		case 0:
@@ -35,6 +35,9 @@ func resourceServerMigrateState(schemaVersion int, instanceState *terraform.Inst
 		case 3:
 			log.Println("Found Server state v3; migrating to v4")
 			migratedState, err = migrateServerStateV3toV4(instanceState)
+		case 4:
+			log.Println("[Migration]Found server state v4; migrating to v5")
+			migratedState, err = migrateServerStateV4toV5(instanceState)
 		default:
 			err = fmt.Errorf("Unexpected schema version: %d", schemaVersion)
 		}
@@ -259,3 +262,24 @@ func migrateServerStateV3toV4(instanceState *terraform.InstanceState) (migratedS
 
 	return
 }
+// Migrate state for ddcloud_server (v3 to v4).
+//
+// From:
+// auto_start: true/false
+//
+// To:
+// power_state: disabled/autostart/start/shutdown/shutdown-hard
+func migrateServerStateV4toV5(instanceState *terraform.InstanceState) (migratedState *terraform.InstanceState, err error) {
+	migratedState = instanceState
+
+	autoStart := migratedState.Attributes[resourceKeyServerAutoStart]
+	if autoStart == "true" {
+		migratedState.Attributes[resourceKeyServerPowerState] = "autostart"
+	}
+	delete(migratedState.Attributes, resourceKeyServerAutoStart)
+
+	log.Printf("[Migration] Server attributes after migratation from v4 to v5: %#v", migratedState.Attributes,)
+
+	return
+}
+

--- a/ddcloud/resource_server_test.go
+++ b/ddcloud/resource_server_test.go
@@ -833,7 +833,7 @@ func testCheckDDCloudServerStarted(name string, started bool) resource.TestCheck
 		}
 		if started && server.Started == false {
 			return fmt.Errorf("bad: server %s not started", serverID)
-		} else if !started && server.Started true {
+		} else if !started && server.Started == true {
 			return fmt.Errorf("bad: server %s is started", serverID)
 		}
 

--- a/ddcloud/resource_server_test.go
+++ b/ddcloud/resource_server_test.go
@@ -513,7 +513,7 @@ func TestAccServerTagUpdate(t *testing.T) {
 }
 
 // Create a server and verify that it auto powers on.
-func TestAccServerAutoPower(t *testing.T) {
+func TestAccServerAutoStart(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -523,7 +523,7 @@ func TestAccServerAutoPower(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDDCloudServerPowerState("start"),
+				Config: testAccDDCloudServerPowerState("autostart"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckDDCloudServerExists("ddcloud_server.acc_test_server", true),
 					testCheckDDCloudServerStartedState("ddcloud_server.acc_test_server", true),
@@ -544,7 +544,7 @@ func TestAccServerPowerStates(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDDCloudServerPowerState("start"),
+				Config: testAccDDCloudServerPowerState("autostart"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckDDCloudServerExists("ddcloud_server.acc_test_server", true),
 					testCheckDDCloudServerStartedState("ddcloud_server.acc_test_server", true),
@@ -565,7 +565,7 @@ func TestAccServerPowerStates(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccDDCloudServerPowerState("off"),
+				Config: testAccDDCloudServerPowerState("shutdown-hard"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckDDCloudServerExists("ddcloud_server.acc_test_server", true),
 					testCheckDDCloudServerStartedState("ddcloud_server.acc_test_server", false),

--- a/ddcloud/resource_server_test.go
+++ b/ddcloud/resource_server_test.go
@@ -305,7 +305,6 @@ func testAccDDCloudServerPowerState(powerState string) string {
 	`, powerState)
 }
 
-
 /*
  * Acceptance tests.
  */
@@ -524,8 +523,7 @@ func TestAccServerBasicCreateAutoPower(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDDCloudServerPowerState("start",
-				),
+				Config: testAccDDCloudServerPowerState("start"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckDDCloudServerExists("ddcloud_server.acc_test_server", true),
 					testCheckDDCloudServerStarted("ddcloud_server.acc_test_server", true),

--- a/ddcloud/resource_server_test.go
+++ b/ddcloud/resource_server_test.go
@@ -277,7 +277,7 @@ func testAccDDCloudServerPowerState(powerState string) string {
 		resource "ddcloud_server" "acc_test_server" {
 			name				= "acc-test-server-power-state"
 			description 		= "Server for Terraform acceptance test (Power State)."
-			admin_password		= "snausages!"
+			admin_password		= "Snausages!"
 
 			memory_gb			= 8
 

--- a/ddcloud/resource_server_test.go
+++ b/ddcloud/resource_server_test.go
@@ -58,6 +58,7 @@ func testAccDDCloudServerBasic(name string, description string, primaryIPv4Addre
 			image				= "CentOS 7 64-bit 2 CPU"
 
 			auto_start			= false
+			power_state         = shutdown
 
 			# Image disk
 			disk {
@@ -249,6 +250,61 @@ func testAccDDCloudServerTag(tags map[string]string) string {
 		}
 	`, tagConfiguration)
 }
+
+// A basic Server (and its accompanying network domain and VLAN).
+func testAccDDCloudServerPowerState(powerState string) string {
+	return fmt.Sprintf(`
+		provider "ddcloud" {
+			region		= "AU"
+		}
+
+		resource "ddcloud_networkdomain" "acc_test_domain" {
+			name		= "acc-test-networkdomain"
+			description	= "Network domain for Terraform acceptance test."
+			datacenter	= "AU9"
+		}
+
+		resource "ddcloud_vlan" "acc_test_vlan" {
+			name				= "acc-test-vlan"
+			description 		= "VLAN for Terraform acceptance test."
+
+			networkdomain 		= "${ddcloud_networkdomain.acc_test_domain.id}"
+
+			ipv4_base_address	= "192.168.17.0"
+			ipv4_prefix_size	= 24
+		}
+
+		resource "ddcloud_server" "acc_test_server" {
+			name				= "acc-test-server-power-state"
+			description 		= "Server for Terraform acceptance test (Power State)."
+			admin_password		= "snausages!"
+
+			memory_gb			= 8
+
+			networkdomain 		= "${ddcloud_networkdomain.acc_test_domain.id}"
+			
+			primary_network_adapter {
+				vlan            = "${ddcloud_vlan.acc_test_vlan.id}"
+				ipv4            = "192.168.17.6"
+			}
+
+			dns_primary			= "8.8.8.8"
+			dns_secondary		= "8.8.4.4"
+
+			image				= "CentOS 7 64-bit 2 CPU"
+
+			power_state         = %s
+
+			# Image disk
+			disk {
+				scsi_unit_id    = 0
+				size_gb         = 10
+				speed           = "STANDARD"
+			}
+		}
+	`, powerState)
+}
+
 
 /*
  * Acceptance tests.
@@ -451,6 +507,28 @@ func TestAccServerTagUpdate(t *testing.T) {
 						"role":      "greetings, earth",
 						"consul_dc": "farewell, luna",
 					}),
+				),
+			},
+		},
+	})
+}
+
+// Create a server and verify that it auto powers on.
+func TestAccServerBasicCreateAutoPower(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckDDCloudServerDestroy,
+			testCheckDDCloudVLANDestroy,
+			testCheckDDCloudNetworkDomainDestroy,
+		),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDDCloudServerPowerState("start",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckDDCloudServerExists("ddcloud_server.acc_test_server", true),
+					testCheckDDCloudServerStarted("ddcloud_server.acc_test_server", true),
 				),
 			},
 		},
@@ -735,5 +813,30 @@ func testDisk(scsiBusNumber int, scsiUnitID int, sizeGB int, speed string) model
 		SCSIUnitID:    scsiUnitID,
 		SizeGB:        sizeGB,
 		Speed:         speed,
+	}
+}
+
+// Check if the server started.
+func testCheckDDCloudServerStarted(name string, started bool) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		res, ok := state.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		serverID := res.Primary.ID
+
+		client := testAccProvider.Meta().(*providerState).Client()
+		server, err := client.GetServer(serverID)
+		if err != nil {
+			return fmt.Errorf("bad: Get server: %s", err)
+		}
+		if started && server.Started == false {
+			return fmt.Errorf("bad: server %s not started", serverID)
+		} else if !started && server.Started true {
+			return fmt.Errorf("bad: server %s is started", serverID)
+		}
+
+		return nil
 	}
 }

--- a/docs/resource_types/server.md
+++ b/docs/resource_types/server.md
@@ -91,10 +91,10 @@ If specified, must be `os`, `customer`, or `auto` (default).
 If not specified, Google DNS (`8.8.8.8`) is used.
 * `dns_secondary` - (Required) The IP address of the server's secondary DNS.  
 If not specified, Google DNS (`8.8.4.4`) is used.
-* `power_state` - (Optional) Sets the Power state of the server (default is off).
-Available Options.
-  * `start` - Starts the server, auto starts if server is being created.
-  * `off'` (default) Hard stops the server.
+* `power_state` - (Optional) Sets the power state of the server.  
+Available Options include.
+  * `start` - Starts the server, auto starts on server creation.
+  * `off` - (default) Hard stops the server, leaves server off on server creation.
   * `shutdown` - Graceful shutdown of the server.
 
 * `tag` - (Optional) A set of tags to apply to the server.

--- a/docs/resource_types/server.md
+++ b/docs/resource_types/server.md
@@ -91,7 +91,9 @@ If specified, must be `os`, `customer`, or `auto` (default).
 If not specified, Google DNS (`8.8.8.8`) is used.
 * `dns_secondary` - (Required) The IP address of the server's secondary DNS.  
 If not specified, Google DNS (`8.8.4.4`) is used.
-* `auto_start` - (Optional) Automatically start the server once it is deployed (default is false).
+* `power_state` - (Optional) Sets the Power state of the server (default is off).
+Must be either `off` (default), `shutdown` - Graceful shutdown if started, or `start` - Will auto start a new server
+
 * `tag` - (Optional) A set of tags to apply to the server.
     * `name` - (Required) The tag name. **Note**: The tag name must already be defined for your organisation.
     * `value` - (Required) The tag value.

--- a/docs/resource_types/server.md
+++ b/docs/resource_types/server.md
@@ -92,7 +92,10 @@ If not specified, Google DNS (`8.8.8.8`) is used.
 * `dns_secondary` - (Required) The IP address of the server's secondary DNS.  
 If not specified, Google DNS (`8.8.4.4`) is used.
 * `power_state` - (Optional) Sets the Power state of the server (default is off).
-Must be either `off` (default), `shutdown` - Graceful shutdown if started, or `start` - Will auto start a new server
+Available Options.
+  * `start` - Starts the server, auto starts if server is being created.
+  * `off'` (default) Hard stops the server.
+  * `shutdown` - Graceful shutdown of the server.
 
 * `tag` - (Optional) A set of tags to apply to the server.
     * `name` - (Required) The tag name. **Note**: The tag name must already be defined for your organisation.

--- a/docs/resource_types/server.md
+++ b/docs/resource_types/server.md
@@ -93,9 +93,11 @@ If not specified, Google DNS (`8.8.8.8`) is used.
 If not specified, Google DNS (`8.8.4.4`) is used.
 * `power_state` - (Optional) Sets the power state of the server.  
 Available Options include.
-  * `start` - Starts the server, auto starts on server creation.
-  * `off` - (default) Hard stops the server, leaves server off on server creation.
-  * `shutdown` - Graceful shutdown of the server.
+  * `autostart` - Starts the server on creation only.
+  * `start` - Starts the server from any shutdown state. Will autostart the server on creation
+  * `shutdown` - Graceful Shutdown of the server.
+  * `shutdown-server` - Hard shutdown of the server.
+  * `disabled` - (Default) Ignore this argument.
 
 * `tag` - (Optional) A set of tags to apply to the server.
     * `name` - (Required) The tag name. **Note**: The tag name must already be defined for your organisation.
@@ -109,6 +111,7 @@ Available Options include.
 * `primary_adapter_ipv6` - The IPv6 address of the server's primary network adapter.
 * `primary_adapter_vlan` - The Id of the VLAN to which the server's primary network adapter is attached. Calculated if `primary_adapter_ipv4` is specified.
 * `public_ipv4` - The server's public IPv4 address (if any). Calculated if there is a NAT rule that points to any of the server's private IPv4 addresses. **Note**: Due to an incompatibility between the CloudControl resource model and Terraform life-cycle model, this attribute is only available after a subsequent refresh (not when the server is first deployed).
+* `started` - The start state of the server. Always calulated. Returns true if server is started
 
 ## Import
 


### PR DESCRIPTION
Creates the ability for the user to change the power state of a server after creation.
Three states can be used
 * `off` - (default) hard turn off the server
* `shutdown` - graceful shutdown of the server
* `start` - starts the server. Auto powers on on server creation.

Auto_Start has been obsoleted by power_state = "start"