### PR TITLE
Implement SSL offload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
     - /^development\/v.*$/
 
 install:
+  - go get golang.org/x/crypto/pkcs12
   - go get github.com/hashicorp/terraform
   - pushd $GOPATH/src/github.com/hashicorp/terraform
   - git checkout v0.9.11

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 # 1.3.1
 
+* Expose SSL-offload profile on `ddcloud_virtual_listener` (DimensionDataResearch/dd-cloud-compute-terraform#104).
 * Implement `ddcloud_ssl_domain_certificate` resource type (DimensionDataResearch/dd-cloud-compute-terraform#104).
 * Implement `ddcloud_ssl_certificate_chain` resource type (DimensionDataResearch/dd-cloud-compute-terraform#104).
 * Implement `ddcloud_pfx` data source (DimensionDataResearch/dd-cloud-compute-terraform#104).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+# 1.3.1
+
+* Implement `ddcloud_ssl_domain_certificate` resource type (DimensionDataResearch/dd-cloud-compute-terraform#104).
+* Implement `ddcloud_ssl_certificate_chain` resource type (DimensionDataResearch/dd-cloud-compute-terraform#104).
+* Implement `ddcloud_pfx` data source (DimensionDataResearch/dd-cloud-compute-terraform#104).
+
 # 1.3.0
 
 * Switch to Terraform v0.9.11.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # 1.3.1
 
 * Expose SSL-offload profile on `ddcloud_virtual_listener` (DimensionDataResearch/dd-cloud-compute-terraform#104).
+* Implement `ddcloud_ssl_offload_profile` resource type (DimensionDataResearch/dd-cloud-compute-terraform#104).
 * Implement `ddcloud_ssl_domain_certificate` resource type (DimensionDataResearch/dd-cloud-compute-terraform#104).
 * Implement `ddcloud_ssl_certificate_chain` resource type (DimensionDataResearch/dd-cloud-compute-terraform#104).
 * Implement `ddcloud_pfx` data source (DimensionDataResearch/dd-cloud-compute-terraform#104).

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROVIDER_NAME = ddcloud
 
-VERSION = 1.3.0
+VERSION = 1.3.1
 VERSION_INFO_FILE = ./$(PROVIDER_NAME)/version-info.go
 
 BIN_DIRECTORY   = _bin

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Currently, the following resource types are supported:
 * `ddcloud_vip_node`: A Virtual IP (VIP) node
 * `ddcloud_vip_pool`: A Virtual IP (VIP) pool
 * `ddcloud_vip_pool_member`: A Virtual IP (VIP) pool membership (node -> pool)
+* `ddcloud_ssl_domain_certificate`: A certificate (with private key) for SSL offload
 
 And the following data-source types are supported:
 
 * `ddcloud_networkdomain`: A network domain (lookup by name and data centre)
 * `ddcloud_vlan`: A VLAN (lookup by name and network domain)
+* `ddcloud_pfx`: A PFX (PKCS12) file (exposes certificate and private key in PEM format, e.g. for use in `ddcloud_ssl_domain_certificate`)
 
 For more information, see the [provider documentation](docs/).
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently, the following resource types are supported:
 * `ddcloud_vip_node`: A Virtual IP (VIP) node
 * `ddcloud_vip_pool`: A Virtual IP (VIP) pool
 * `ddcloud_vip_pool_member`: A Virtual IP (VIP) pool membership (node -> pool)
+* `ddcloud_ssl_offload_profile`: An SSL-offload profile used by a Virtual Listener
 * `ddcloud_ssl_domain_certificate`: An X.509 certificate (with private key) for SSL offload
 * `ddcloud_ssl_certificate_chain`: An X.509 certificate chain for SSL offload
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Currently, the following resource types are supported:
 * `ddcloud_vip_node`: A Virtual IP (VIP) node
 * `ddcloud_vip_pool`: A Virtual IP (VIP) pool
 * `ddcloud_vip_pool_member`: A Virtual IP (VIP) pool membership (node -> pool)
-* `ddcloud_ssl_domain_certificate`: A certificate (with private key) for SSL offload
+* `ddcloud_ssl_domain_certificate`: An X.509 certificate (with private key) for SSL offload
+* `ddcloud_ssl_certificate_chain`: An X.509 certificate chain for SSL offload
 
 And the following data-source types are supported:
 
 * `ddcloud_networkdomain`: A network domain (lookup by name and data centre)
 * `ddcloud_vlan`: A VLAN (lookup by name and network domain)
-* `ddcloud_pfx`: A PFX (PKCS12) file (exposes certificate and private key in PEM format, e.g. for use in `ddcloud_ssl_domain_certificate`)
+* `ddcloud_pfx`: A PFX (PKCS12) file (exposes certificate and private key in PEM format, e.g. for use with `ddcloud_ssl_domain_certificate`)
 
 For more information, see the [provider documentation](docs/).
 

--- a/ddcloud/datasource_pfx.go
+++ b/ddcloud/datasource_pfx.go
@@ -2,7 +2,6 @@ package ddcloud
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/pem"
 	"io/ioutil"
 	"log"
@@ -17,8 +16,6 @@ const (
 	resourceKeyPFXCertificate = "certificate"
 	resourceKeyPFXPrivateKey  = "private_key"
 )
-
-var pemBase64 = base64.StdEncoding
 
 func dataSourcePFX() *schema.Resource {
 	return &schema.Resource{

--- a/ddcloud/datasource_pfx.go
+++ b/ddcloud/datasource_pfx.go
@@ -1,0 +1,114 @@
+package ddcloud
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/pem"
+	"io/ioutil"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"golang.org/x/crypto/pkcs12"
+)
+
+const (
+	resourceKeyPFXFile        = "file"
+	resourceKeyPFXPassword    = "password"
+	resourceKeyPFXCertificate = "certificate"
+	resourceKeyPFXPrivateKey  = "private_key"
+)
+
+var pemBase64 = base64.StdEncoding
+
+func dataSourcePFX() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePFXRead,
+
+		Schema: map[string]*schema.Schema{
+			resourceKeyPFXFile: &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the PFX file",
+			},
+			resourceKeyPFXPassword: &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The password for the PFX file",
+			},
+			resourceKeyPFXCertificate: &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The (first) certificate in the PFX file",
+			},
+			resourceKeyPFXPrivateKey: &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The (first) private key in the PFX file",
+			},
+		},
+	}
+}
+
+// Read a network domain data source.
+func dataSourcePFXRead(data *schema.ResourceData, provider interface{}) error {
+	fileName := data.Get(resourceKeyPFXFile).(string)
+
+	pfxData, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		log.Printf("Failed to read PFX data from '%s': %s", fileName, err.Error())
+
+		return err
+	}
+
+	log.Printf("Read PFX data from '%s'.", fileName)
+
+	pfxPassword := data.Get(resourceKeyPFXPassword).(string)
+	pemBlocks, err := pkcs12.ToPEM(pfxData, pfxPassword)
+	if err != nil {
+		log.Printf("Failed to decode PFX data from '%s': %s", fileName, err.Error())
+
+		return err
+	}
+
+	var (
+		certificatePEM string
+		privateKeyPEM  string
+	)
+	for _, pemBlock := range pemBlocks {
+		switch pemBlock.Type {
+		case "CERTIFICATE":
+			if certificatePEM == "" {
+				certificatePEM, err = pemToString(pemBlock)
+				if err != nil {
+					return err
+				}
+			}
+		case "PRIVATE KEY":
+			if privateKeyPEM == "" {
+				privateKeyPEM, err = pemToString(pemBlock)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	data.Set(resourceKeyPFXCertificate, certificatePEM)
+	data.Set(resourceKeyPFXPrivateKey, privateKeyPEM)
+
+	return nil
+}
+
+func pemToString(pemBlock *pem.Block) (string, error) {
+	var buffer bytes.Buffer
+	err := pem.Encode(&buffer, pemBlock)
+	if err != nil {
+		log.Printf("Failed to decode '%s' PEM block: %s", pemBlock.Type, err.Error())
+
+		return "", err
+	}
+
+	return buffer.String(), nil
+}

--- a/ddcloud/provider.go
+++ b/ddcloud/provider.go
@@ -111,6 +111,9 @@ func Provider() terraform.ResourceProvider {
 			// A virtual listener is the top-level entity for load-balancing functionality.
 			"ddcloud_virtual_listener": resourceVirtualListener(),
 
+			// An SSL-offload profile for a virtual listener.
+			"ddcloud_ssl_offload_profile": resourceSSLOffloadProfile(),
+
 			// An SSL certificate (with private key) for a domain.
 			"ddcloud_ssl_domain_certificate": resourceSSLDomainCertificate(),
 

--- a/ddcloud/provider.go
+++ b/ddcloud/provider.go
@@ -114,6 +114,9 @@ func Provider() terraform.ResourceProvider {
 			// An SSL certificate (with private key) for a domain.
 			"ddcloud_ssl_domain_certificate": resourceSSLDomainCertificate(),
 
+			// An SSL certificate chain.
+			"ddcloud_ssl_certificate_chain": resourceSSLCertificateChain(),
+
 			// A reserved IPv6 or private IPv4 address on a VLAN.
 			"ddcloud_ip_address_reservation": resourceIPAddressReservation(),
 		},

--- a/ddcloud/provider.go
+++ b/ddcloud/provider.go
@@ -111,6 +111,9 @@ func Provider() terraform.ResourceProvider {
 			// A virtual listener is the top-level entity for load-balancing functionality.
 			"ddcloud_virtual_listener": resourceVirtualListener(),
 
+			// An SSL certificate (with private key) for a domain.
+			"ddcloud_ssl_domain_certificate": resourceSSLDomainCertificate(),
+
 			// A reserved IPv6 or private IPv4 address on a VLAN.
 			"ddcloud_ip_address_reservation": resourceIPAddressReservation(),
 		},

--- a/ddcloud/provider.go
+++ b/ddcloud/provider.go
@@ -121,6 +121,9 @@ func Provider() terraform.ResourceProvider {
 
 			// A virtual network (VLAN).
 			"ddcloud_vlan": dataSourceVLAN(),
+
+			// A PKCS12 (PFX) file.
+			"ddcloud_pfx": dataSourcePFX(),
 		},
 
 		// Provider configuration

--- a/ddcloud/resource_ssl_certificate_chain.go
+++ b/ddcloud/resource_ssl_certificate_chain.go
@@ -1,0 +1,221 @@
+package ddcloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/DimensionDataResearch/dd-cloud-compute-terraform/retry"
+	"github.com/DimensionDataResearch/go-dd-cloud-compute/compute"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	resourceKeySSLCertificateChainNetworkDomainID = "networkdomain"
+	resourceKeySSLCertificateChainName            = "name"
+	resourceKeySSLCertificateChainDescription     = "description"
+	resourceKeySSLCertificateChainChain           = "chain"
+)
+
+func resourceSSLCertificateChain() *schema.Resource {
+	return &schema.Resource{
+		Exists: resourceSSLCertificateChainExists,
+		Create: resourceSSLCertificateChainCreate,
+		Read:   resourceSSLCertificateChainRead,
+		Update: resourceSSLCertificateChainUpdate,
+		Delete: resourceSSLCertificateChainDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSSLCertificateChainImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			resourceKeySSLCertificateChainNetworkDomainID: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The Id of the network domain in which the SSL certificate chain will be used for SSL offload.",
+			},
+			resourceKeySSLCertificateChainName: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The name of the SSL certificate chain.",
+			},
+			resourceKeySSLCertificateChainDescription: &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     nil,
+				Description: "A description of the SSL certificate chain.",
+			},
+			resourceKeySSLCertificateChainChain: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The certificate chain (in PEM format).",
+			},
+		},
+	}
+}
+
+// Check if a ddcloud_ssl_domain_certificate resource exists.
+func resourceSSLCertificateChainExists(data *schema.ResourceData, provider interface{}) (bool, error) {
+	id := data.Id()
+	log.Printf("Check if SSL certificate chain '%s' exists.", id)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	SSLCertificateChain, err := apiClient.GetSSLCertificateChain(id)
+	if err != nil {
+		return false, err
+	}
+
+	exists := SSLCertificateChain != nil
+
+	log.Printf("SSL certificate chain '%s' exists: %t.", id, exists)
+
+	return exists, nil
+}
+
+// Create a ddcloud_ssl_domain_certificate resource.
+func resourceSSLCertificateChainCreate(data *schema.ResourceData, provider interface{}) error {
+	var err error
+
+	networkDomainID := data.Get(resourceKeySSLCertificateChainNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLCertificateChainName).(string)
+	description := data.Get(resourceKeySSLCertificateChainDescription).(string)
+	chainPEM := data.Get(resourceKeySSLCertificateChainChain).(string)
+
+	log.Printf("Create SSL certificate chain '%s' in network domain '%s'.", name, networkDomainID)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	var (
+		certificateChainID string
+		createError        error
+	)
+
+	operationDescription := fmt.Sprintf("Create SSL certificate chain '%s' in network domain '%s'.", name, networkDomainID)
+	err = providerState.RetryAction(operationDescription, func(context retry.Context) {
+		// CloudControl has issues if more than one asynchronous operation is initated at a time (returns UNEXPECTED_ERROR).
+		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
+		defer asyncLock.Release() // Released at the end of the current attempt.
+
+		certificateChainID, createError = apiClient.ImportSSLCertificateChain(networkDomainID, name, description, chainPEM)
+		if createError != nil {
+			if compute.IsResourceBusyError(createError) {
+				context.Retry()
+			} else {
+				context.Fail(createError)
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	data.SetId(certificateChainID)
+	log.Printf("Successfully created SSL certificate chain '%s'.", certificateChainID)
+
+	certificateChain, err := apiClient.GetSSLCertificateChain(certificateChainID)
+	if err != nil {
+		return err
+	}
+
+	if certificateChain == nil {
+		return fmt.Errorf("cannot find newly-added SSL certificate chain '%s'", certificateChainID)
+	}
+
+	return nil
+}
+
+// Read a ddcloud_ssl_domain_certificate resource.
+func resourceSSLCertificateChainRead(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLCertificateChainNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLCertificateChainName).(string)
+
+	log.Printf("Read SSL certificate chain '%s' ('%s') in network domain '%s'.", name, id, networkDomainID)
+
+	apiClient := provider.(*providerState).Client()
+
+	certificateChain, err := apiClient.GetSSLCertificateChain(id)
+	if err != nil {
+		return err
+	}
+	if certificateChain == nil {
+		data.SetId("") // SSL certificate chain has been deleted
+
+		return nil
+	}
+
+	return nil
+}
+
+// Update a ddcloud_ssl_domain_certificate resource.
+func resourceSSLCertificateChainUpdate(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLCertificateChainNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLCertificateChainName).(string)
+
+	log.Printf("Update SSL certificate chain '%s' ('%s') in network domain '%s' (nothing to do).", name, id, networkDomainID)
+
+	return nil
+}
+
+// Delete a ddcloud_ssl_domain_certificate resource.
+func resourceSSLCertificateChainDelete(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLCertificateChainNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLCertificateChainName).(string)
+
+	log.Printf("Delete SSL certificate chain '%s' ('%s') in network domain '%s' (nothing to do).", name, id, networkDomainID)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	operationDescription := fmt.Sprintf("Delete SSL certificate chain '%s", id)
+
+	return providerState.RetryAction(operationDescription, func(context retry.Context) {
+		// CloudControl has issues if more than one asynchronous operation is initated at a time (returns UNEXPECTED_ERROR).
+		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
+		defer asyncLock.Release() // Released at the end of the current attempt.
+
+		err := apiClient.DeleteSSLCertificateChain(id)
+		if err != nil {
+			if compute.IsResourceBusyError(err) {
+				context.Retry()
+			} else {
+				context.Fail(err)
+			}
+		}
+	})
+}
+
+// Import data for an existing SSL certificate chain.
+func resourceSSLCertificateChainImport(data *schema.ResourceData, provider interface{}) (importedData []*schema.ResourceData, err error) {
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	id := data.Id()
+	log.Printf("Import SSL certificate chain '%s'.", id)
+
+	var certificateChain *compute.SSLCertificateChain
+	certificateChain, err = apiClient.GetSSLCertificateChain(id)
+	if err != nil {
+		return
+	}
+	if certificateChain == nil {
+		err = fmt.Errorf("SSL certificate chain '%s' not found", id)
+
+		return
+	}
+
+	data.Set(resourceKeySSLCertificateChainNetworkDomainID, certificateChain.NetworkDomainID)
+	data.Set(resourceKeySSLCertificateChainName, certificateChain.Name)
+	data.Set(resourceKeySSLCertificateChainDescription, certificateChain.Description)
+
+	importedData = []*schema.ResourceData{data}
+
+	return
+}

--- a/ddcloud/resource_ssl_domain_certificate.go
+++ b/ddcloud/resource_ssl_domain_certificate.go
@@ -1,0 +1,230 @@
+package ddcloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/DimensionDataResearch/dd-cloud-compute-terraform/retry"
+	"github.com/DimensionDataResearch/go-dd-cloud-compute/compute"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	resourceKeySSLDomainCertificateNetworkDomainID = "networkdomain"
+	resourceKeySSLDomainCertificateName            = "name"
+	resourceKeySSLDomainCertificateDescription     = "description"
+	resourceKeySSLDomainCertificateCertificate     = "certificate"
+	resourceKeySSLDomainCertificatePrivateKey      = "private_key"
+)
+
+func resourceSSLDomainCertificate() *schema.Resource {
+	return &schema.Resource{
+		Exists: resourceSSLDomainCertificateExists,
+		Create: resourceSSLDomainCertificateCreate,
+		Read:   resourceSSLDomainCertificateRead,
+		Update: resourceSSLDomainCertificateUpdate,
+		Delete: resourceSSLDomainCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSSLDomainCertificateImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			resourceKeySSLDomainCertificateNetworkDomainID: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The Id of the network domain in which the SSL domain certificate will be used for SSL offload.",
+			},
+			resourceKeySSLDomainCertificateName: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The name of the SSL domain certificate.",
+			},
+			resourceKeySSLDomainCertificateDescription: &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     nil,
+				Description: "A description of the SSL domain certificate.",
+			},
+			resourceKeySSLDomainCertificateCertificate: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The certificate (in PEM format).",
+			},
+			resourceKeySSLDomainCertificatePrivateKey: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The certificate's private key (in PEM format).",
+			},
+		},
+	}
+}
+
+// Check if a ddcloud_ssl_domain_certificate resource exists.
+func resourceSSLDomainCertificateExists(data *schema.ResourceData, provider interface{}) (bool, error) {
+	id := data.Id()
+	log.Printf("Check if SSL domain certificate '%s' exists.", id)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	SSLDomainCertificate, err := apiClient.GetSSLDomainCertificate(id)
+	if err != nil {
+		return false, err
+	}
+
+	exists := SSLDomainCertificate != nil
+
+	log.Printf("SSL domain certificate '%s' exists: %t.", id, exists)
+
+	return exists, nil
+}
+
+// Create a ddcloud_ssl_domain_certificate resource.
+func resourceSSLDomainCertificateCreate(data *schema.ResourceData, provider interface{}) error {
+	var err error
+
+	networkDomainID := data.Get(resourceKeySSLDomainCertificateNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLDomainCertificateName).(string)
+	description := data.Get(resourceKeySSLDomainCertificateDescription).(string)
+	certificatePEM := data.Get(resourceKeySSLDomainCertificateCertificate).(string)
+	privateKeyPEM := data.Get(resourceKeySSLDomainCertificatePrivateKey).(string)
+
+	log.Printf("Create SSL domain certificate '%s' in network domain '%s'.", name, networkDomainID)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	var (
+		domainCertificateID string
+		createError         error
+	)
+
+	operationDescription := fmt.Sprintf("Create SSL domain certificate '%s' in network domain '%s'.", name, networkDomainID)
+	err = providerState.RetryAction(operationDescription, func(context retry.Context) {
+		// CloudControl has issues if more than one asynchronous operation is initated at a time (returns UNEXPECTED_ERROR).
+		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
+		defer asyncLock.Release() // Released at the end of the current attempt.
+
+		domainCertificateID, createError = apiClient.ImportSSLDomainCertificate(networkDomainID, name, description, certificatePEM, privateKeyPEM)
+		if createError != nil {
+			if compute.IsResourceBusyError(createError) {
+				context.Retry()
+			} else {
+				context.Fail(createError)
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	data.SetId(domainCertificateID)
+	log.Printf("Successfully created SSL domain certificate '%s'.", domainCertificateID)
+
+	domainCertificate, err := apiClient.GetSSLDomainCertificate(domainCertificateID)
+	if err != nil {
+		return err
+	}
+
+	if domainCertificate == nil {
+		return fmt.Errorf("cannot find newly-added SSL domain certificate '%s'", domainCertificateID)
+	}
+
+	return nil
+}
+
+// Read a ddcloud_ssl_domain_certificate resource.
+func resourceSSLDomainCertificateRead(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLDomainCertificateNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLDomainCertificateName).(string)
+
+	log.Printf("Read SSL domain certificate '%s' ('%s') in network domain '%s'.", name, id, networkDomainID)
+
+	apiClient := provider.(*providerState).Client()
+
+	SSLDomainCertificate, err := apiClient.GetSSLDomainCertificate(id)
+	if err != nil {
+		return err
+	}
+	if SSLDomainCertificate == nil {
+		data.SetId("") // SSL domain certificate has been deleted
+
+		return nil
+	}
+
+	return nil
+}
+
+// Update a ddcloud_ssl_domain_certificate resource.
+func resourceSSLDomainCertificateUpdate(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLDomainCertificateNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLDomainCertificateName).(string)
+
+	log.Printf("Update SSL domain certificate '%s' ('%s') in network domain '%s' (nothing to do).", name, id, networkDomainID)
+
+	return nil
+}
+
+// Delete a ddcloud_ssl_domain_certificate resource.
+func resourceSSLDomainCertificateDelete(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLDomainCertificateNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLDomainCertificateName).(string)
+
+	log.Printf("Delete SSL domain certificate '%s' ('%s') in network domain '%s' (nothing to do).", name, id, networkDomainID)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	operationDescription := fmt.Sprintf("Delete SSL domain certificate '%s", id)
+
+	return providerState.RetryAction(operationDescription, func(context retry.Context) {
+		// CloudControl has issues if more than one asynchronous operation is initated at a time (returns UNEXPECTED_ERROR).
+		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
+		defer asyncLock.Release() // Released at the end of the current attempt.
+
+		err := apiClient.DeleteSSLDomainCertificate(id)
+		if err != nil {
+			if compute.IsResourceBusyError(err) {
+				context.Retry()
+			} else {
+				context.Fail(err)
+			}
+		}
+	})
+}
+
+// Import data for an existing SSL domain certificate.
+func resourceSSLDomainCertificateImport(data *schema.ResourceData, provider interface{}) (importedData []*schema.ResourceData, err error) {
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	id := data.Id()
+	log.Printf("Import SSL domain certificate '%s'.", id)
+
+	var domainCertificate *compute.SSLDomainCertificate
+	domainCertificate, err = apiClient.GetSSLDomainCertificate(id)
+	if err != nil {
+		return
+	}
+	if domainCertificate == nil {
+		err = fmt.Errorf("SSL domain certificate '%s' not found", id)
+
+		return
+	}
+
+	data.Set(resourceKeySSLDomainCertificateNetworkDomainID, domainCertificate.NetworkDomainID)
+	data.Set(resourceKeySSLDomainCertificateName, domainCertificate.Name)
+	data.Set(resourceKeySSLDomainCertificateDescription, domainCertificate.Description)
+
+	importedData = []*schema.ResourceData{data}
+
+	return
+}

--- a/ddcloud/resource_ssl_domain_certificate.go
+++ b/ddcloud/resource_ssl_domain_certificate.go
@@ -94,6 +94,9 @@ func resourceSSLDomainCertificateCreate(data *schema.ResourceData, provider inte
 	certificatePEM := data.Get(resourceKeySSLDomainCertificateCertificate).(string)
 	privateKeyPEM := data.Get(resourceKeySSLDomainCertificatePrivateKey).(string)
 
+	// Don't persist the private key in the state file.
+	data.Set(resourceKeySSLDomainCertificatePrivateKey, "")
+
 	log.Printf("Create SSL domain certificate '%s' in network domain '%s'.", name, networkDomainID)
 
 	providerState := provider.(*providerState)

--- a/ddcloud/resource_ssl_offload_profile.go
+++ b/ddcloud/resource_ssl_offload_profile.go
@@ -1,0 +1,313 @@
+package ddcloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/DimensionDataResearch/dd-cloud-compute-terraform/retry"
+	"github.com/DimensionDataResearch/go-dd-cloud-compute/compute"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	resourceKeySSLOffloadProfileNetworkDomainID = "networkdomain"
+	resourceKeySSLOffloadProfileName            = "name"
+	resourceKeySSLOffloadProfileDescription     = "description"
+	resourceKeySSLOffloadProfileCiphers         = "ciphers"
+	resourceKeySSLOffloadProfileCertificateID   = "certificate"
+	resourceKeySSLOffloadProfileChainID         = "chain"
+)
+
+func resourceSSLOffloadProfile() *schema.Resource {
+	return &schema.Resource{
+		Exists: resourceSSLOffloadProfileExists,
+		Create: resourceSSLOffloadProfileCreate,
+		Read:   resourceSSLOffloadProfileRead,
+		Update: resourceSSLOffloadProfileUpdate,
+		Delete: resourceSSLOffloadProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSSLOffloadProfileImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			resourceKeySSLOffloadProfileNetworkDomainID: &schema.Schema{
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The Id of the network domain in which the SSL-offload profile will be create.",
+			},
+			resourceKeySSLOffloadProfileName: &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the SSL-offload profile.",
+			},
+			resourceKeySSLOffloadProfileDescription: &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     nil,
+				Description: "A description of the SSL-offload profile.",
+			},
+			resourceKeySSLOffloadProfileCertificateID: &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The Id of the SSL domain certificate to use.",
+			},
+			resourceKeySSLOffloadProfileChainID: &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The Id of the SSL certificate chain to use.",
+			},
+			resourceKeySSLOffloadProfileCiphers: &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The SSL ciphers use.",
+			},
+		},
+	}
+}
+
+// Check if a ddcloud_ssl_domain_certificate resource exists.
+func resourceSSLOffloadProfileExists(data *schema.ResourceData, provider interface{}) (bool, error) {
+	id := data.Id()
+	log.Printf("Check if SSL-offload profile '%s' exists.", id)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	sslOffloadProfile, err := apiClient.GetSSLOffloadProfile(id)
+	if err != nil {
+		return false, err
+	}
+
+	exists := sslOffloadProfile != nil
+
+	log.Printf("SSL-offload profile '%s' exists: %t.", id, exists)
+
+	return exists, nil
+}
+
+// Create a ddcloud_ssl_domain_certificate resource.
+func resourceSSLOffloadProfileCreate(data *schema.ResourceData, provider interface{}) error {
+	var err error
+
+	propertyHelper := propertyHelper(data)
+
+	networkDomainID := data.Get(resourceKeySSLOffloadProfileNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLOffloadProfileName).(string)
+	description := data.Get(resourceKeySSLOffloadProfileDescription).(string)
+	certificateID := data.Get(resourceKeySSLOffloadProfileCertificateID).(string)
+	chainID := data.Get(resourceKeySSLOffloadProfileChainID).(string)
+	ciphers := propertyHelper.GetOptionalString(resourceKeySSLOffloadProfileCiphers, false)
+
+	log.Printf("Create SSL-offload profile '%s' in network domain '%s'.", name, networkDomainID)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	var (
+		sslOffloadProfileID string
+		createError         error
+	)
+
+	operationDescription := fmt.Sprintf("Create SSL-offload profile '%s' in network domain '%s'.", name, networkDomainID)
+	err = providerState.RetryAction(operationDescription, func(context retry.Context) {
+		// CloudControl has issues if more than one asynchronous operation is initated at a time (returns UNEXPECTED_ERROR).
+		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
+		defer asyncLock.Release() // Released at the end of the current attempt.
+
+		sslOffloadProfileID, createError = apiClient.CreateSSLOffloadProfile(networkDomainID, name, description, ciphers, certificateID, chainID)
+		if createError != nil {
+			if compute.IsResourceBusyError(createError) {
+				context.Retry()
+			} else {
+				context.Fail(createError)
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	data.SetId(sslOffloadProfileID)
+	log.Printf("Successfully created SSL-offload profile '%s'.", sslOffloadProfileID)
+
+	sslOffloadProfile, err := apiClient.GetSSLOffloadProfile(sslOffloadProfileID)
+	if err != nil {
+		return err
+	}
+
+	if sslOffloadProfile == nil {
+		return fmt.Errorf("cannot find newly-added SSL-offload profile '%s'", sslOffloadProfileID)
+	}
+
+	data.Set(resourceKeySSLOffloadProfileCiphers, sslOffloadProfile.Ciphers)
+
+	return nil
+}
+
+// Read a ddcloud_ssl_domain_certificate resource.
+func resourceSSLOffloadProfileRead(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLOffloadProfileNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLOffloadProfileName).(string)
+
+	log.Printf("Read SSL-offload profile '%s' ('%s') in network domain '%s'.", name, id, networkDomainID)
+
+	apiClient := provider.(*providerState).Client()
+
+	sslOffloadProfile, err := apiClient.GetSSLOffloadProfile(id)
+	if err != nil {
+		return err
+	}
+	if sslOffloadProfile == nil {
+		data.SetId("") // SSL-offload profile has been deleted
+
+		return nil
+	}
+
+	data.Set(resourceKeySSLOffloadProfileCiphers, sslOffloadProfile.Ciphers)
+
+	return nil
+}
+
+// Update a ddcloud_ssl_domain_certificate resource.
+func resourceSSLOffloadProfileUpdate(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLOffloadProfileNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLOffloadProfileName).(string)
+
+	log.Printf("Update SSL-offload profile '%s' ('%s') in network domain '%s'.", name, id, networkDomainID)
+
+	hasChange := false
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	sslOffloadProfile, err := apiClient.GetSSLOffloadProfile(id)
+	if err != nil {
+		return err
+	}
+	if sslOffloadProfile == nil {
+		data.SetId("") // SSL-offload profile has been deleted
+
+		return nil
+	}
+
+	if data.HasChange(resourceKeySSLOffloadProfileName) {
+		sslOffloadProfile.Name = data.Get(resourceKeySSLOffloadProfileName).(string)
+
+		hasChange = true
+	}
+
+	if data.HasChange(resourceKeySSLOffloadProfileDescription) {
+		sslOffloadProfile.Description = data.Get(resourceKeySSLOffloadProfileDescription).(string)
+
+		hasChange = true
+	}
+
+	if data.HasChange(resourceKeySSLOffloadProfileCertificateID) {
+		sslOffloadProfile.SSLDomainCertificate.ID = data.Get(resourceKeySSLOffloadProfileCertificateID).(string)
+
+		hasChange = true
+	}
+
+	if data.HasChange(resourceKeySSLOffloadProfileChainID) {
+		sslOffloadProfile.SSLCertificateChain.ID = data.Get(resourceKeySSLOffloadProfileChainID).(string)
+
+		hasChange = true
+	}
+
+	if data.HasChange(resourceKeySSLOffloadProfileCiphers) {
+		sslOffloadProfile.Ciphers = data.Get(resourceKeySSLOffloadProfileCiphers).(string)
+
+		hasChange = true
+	}
+
+	if !hasChange {
+		return nil
+	}
+
+	var editError error
+
+	operationDescription := fmt.Sprintf("Create SSL-offload profile '%s' in network domain '%s'.", name, networkDomainID)
+	err = providerState.RetryAction(operationDescription, func(context retry.Context) {
+		// CloudControl has issues if more than one asynchronous operation is initated at a time (returns UNEXPECTED_ERROR).
+		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
+		defer asyncLock.Release() // Released at the end of the current attempt.
+
+		editError = apiClient.EditSSLOffloadProfile(*sslOffloadProfile)
+		if editError != nil {
+			if compute.IsResourceBusyError(editError) {
+				context.Retry()
+			} else {
+				context.Fail(editError)
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete a ddcloud_ssl_domain_certificate resource.
+func resourceSSLOffloadProfileDelete(data *schema.ResourceData, provider interface{}) error {
+	id := data.Id()
+	networkDomainID := data.Get(resourceKeySSLOffloadProfileNetworkDomainID).(string)
+	name := data.Get(resourceKeySSLOffloadProfileName).(string)
+
+	log.Printf("Delete SSL-offload profile '%s' ('%s') in network domain '%s' (nothing to do).", name, id, networkDomainID)
+
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	operationDescription := fmt.Sprintf("Delete SSL-offload profile '%s", id)
+
+	return providerState.RetryAction(operationDescription, func(context retry.Context) {
+		// CloudControl has issues if more than one asynchronous operation is initated at a time (returns UNEXPECTED_ERROR).
+		asyncLock := providerState.AcquireAsyncOperationLock(operationDescription)
+		defer asyncLock.Release() // Released at the end of the current attempt.
+
+		err := apiClient.DeleteSSLOffloadProfile(id)
+		if err != nil {
+			if compute.IsResourceBusyError(err) {
+				context.Retry()
+			} else {
+				context.Fail(err)
+			}
+		}
+	})
+}
+
+// Import data for an existing SSL-offload profile.
+func resourceSSLOffloadProfileImport(data *schema.ResourceData, provider interface{}) (importedData []*schema.ResourceData, err error) {
+	providerState := provider.(*providerState)
+	apiClient := providerState.Client()
+
+	id := data.Id()
+	log.Printf("Import SSL-offload profile '%s'.", id)
+
+	var sslOffloadProfile *compute.SSLOffloadProfile
+	sslOffloadProfile, err = apiClient.GetSSLOffloadProfile(id)
+	if err != nil {
+		return
+	}
+	if sslOffloadProfile == nil {
+		err = fmt.Errorf("SSL-offload profile '%s' not found", id)
+
+		return
+	}
+
+	data.Set(resourceKeySSLOffloadProfileNetworkDomainID, sslOffloadProfile.NetworkDomainID)
+	data.Set(resourceKeySSLOffloadProfileName, sslOffloadProfile.Name)
+	data.Set(resourceKeySSLOffloadProfileDescription, sslOffloadProfile.Description)
+	data.Set(resourceKeySSLOffloadProfileCiphers, sslOffloadProfile.Ciphers)
+	data.Set(resourceKeySSLOffloadProfileCertificateID, sslOffloadProfile.SSLDomainCertificate.ID)
+	data.Set(resourceKeySSLOffloadProfileChainID, sslOffloadProfile.SSLCertificateChain.ID)
+
+	importedData = []*schema.ResourceData{data}
+
+	return
+}

--- a/ddcloud/resource_virtual_listener.go
+++ b/ddcloud/resource_virtual_listener.go
@@ -22,6 +22,7 @@ const (
 	resourceKeyVirtualListenerSourcePortPreservation = "source_port_preservation"
 	resourceKeyVirtualListenerPoolID                 = "pool"
 	resourceKeyVirtualListenerPersistenceProfileName = "persistence_profile"
+	resourceKeyVirtualListenerSSLOffloadProfileID    = "ssl_offload_profile"
 	resourceKeyVirtualListenerIRuleNames             = "irules"
 	resourceKeyVirtualListenerOptimizationProfiles   = "optimization_profiles"
 	resourceKeyVirtualListenerNetworkDomainID        = "networkdomain"
@@ -135,6 +136,11 @@ func resourceVirtualListener() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
+			resourceKeyVirtualListenerSSLOffloadProfileID: &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  nil,
+			},
 			resourceKeyVirtualListenerIRuleNames: &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -219,6 +225,7 @@ func resourceVirtualListenerCreate(data *schema.ResourceData, provider interface
 			SourcePortPreservation: data.Get(resourceKeyVirtualListenerSourcePortPreservation).(string),
 			PoolID:                 propertyHelper.GetOptionalString(resourceKeyVirtualListenerPoolID, false),
 			PersistenceProfileID:   persistenceProfileID,
+			SSLOffloadProfileID:    propertyHelper.GetOptionalString(resourceKeyVirtualListenerSSLOffloadProfileID, false),
 			IRuleIDs:               iRuleIDs,
 			OptimizationProfiles:   propertyHelper.GetStringSetItems(resourceKeyVirtualListenerOptimizationProfiles),
 			NetworkDomainID:        networkDomainID,
@@ -310,6 +317,7 @@ func resourceVirtualListenerRead(data *schema.ResourceData, provider interface{}
 	data.Set(resourceKeyVirtualListenerConnectionRateLimit, virtualListener.ConnectionRateLimit)
 	data.Set(resourceKeyVirtualListenerSourcePortPreservation, virtualListener.SourcePortPreservation)
 	data.Set(resourceKeyVirtualListenerPersistenceProfileName, virtualListener.PersistenceProfile.Name)
+	data.Set(resourceKeyVirtualListenerSSLOffloadProfileID, virtualListener.SSLOffloadProfile.ID)
 	data.Set(resourceKeyVirtualListenerIPv4Address, virtualListener.ListenerIPAddress)
 
 	propertyHelper := propertyHelper(data)
@@ -352,6 +360,10 @@ func resourceVirtualListenerUpdate(data *schema.ResourceData, provider interface
 
 	if data.HasChange(resourceKeyVirtualListenerPoolID) {
 		configuration.PoolID = propertyHelper.GetOptionalString(resourceKeyVirtualListenerPoolID, true)
+	}
+
+	if data.HasChange(resourceKeyVirtualListenerSSLOffloadProfileID) {
+		configuration.SSLOffloadProfileID = propertyHelper.GetOptionalString(resourceKeyVirtualListenerSSLOffloadProfileID, false)
 	}
 
 	if data.HasChange(resourceKeyVirtualListenerPersistenceProfileName) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ The `ddcloud` provider supports the following resource types:
 * [ddcloud_vip_pool_member](resource_types/vip_pool_member.md) - A CloudControl Virtual IP (VIP) pool membership.  
 Links a `ddcloud_vip_node` (and optionally a port) to a `ddcloud_vip_pool`.
 * [ddcloud_virtual_listener](resource_types/virtual_listener.md) - A CloudControl Virtual Listener.
+* [ssl_domain_certificate](resource_types/ssl_domain_certificate.md) - A certificate (with private key) for SSL offload.
 * [ddcloud_ip_address_reservation](resource_types/ip_address_reservation.md) - An IP address reservation on a CloudControl VLAN (experimental, for advanced usage scenarios only).
 
 And the following data-source types:

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ And the following data-source types:
 
 * [ddcloud_networkdomain](datasource_types/networkdomain.md) - A CloudControl network domain (lookup by name and data centre).
 * [ddcloud_vlan](datasource_types/vlan.md) - A CloudControl Virtual LAN (VLAN) (lookup by name and network domain).
+* [ddcloud_pfx](datasource_types/pfx.md) - Enables decoding of a `.pfx` file into PEM-format certificate and private key (useful for SSL-offload resources).
 
 ## Migration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,8 @@ The `ddcloud` provider supports the following resource types:
 * [ddcloud_vip_pool_member](resource_types/vip_pool_member.md) - A CloudControl Virtual IP (VIP) pool membership.  
 Links a `ddcloud_vip_node` (and optionally a port) to a `ddcloud_vip_pool`.
 * [ddcloud_virtual_listener](resource_types/virtual_listener.md) - A CloudControl Virtual Listener.
-* [ssl_domain_certificate](resource_types/ssl_domain_certificate.md) - A certificate (with private key) for SSL offload.
+* [ssl_domain_certificate](resource_types/ssl_domain_certificate.md) - An X.509 certificate (with private key) for SSL offload.
+* [ssl_certificate_chain](resource_types/ssl_certificate_chain.md) - An X.509 certificate chain for SSL offload.
 * [ddcloud_ip_address_reservation](resource_types/ip_address_reservation.md) - An IP address reservation on a CloudControl VLAN (experimental, for advanced usage scenarios only).
 
 And the following data-source types:

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ The `ddcloud` provider supports the following resource types:
 * [ddcloud_vip_pool_member](resource_types/vip_pool_member.md) - A CloudControl Virtual IP (VIP) pool membership.  
 Links a `ddcloud_vip_node` (and optionally a port) to a `ddcloud_vip_pool`.
 * [ddcloud_virtual_listener](resource_types/virtual_listener.md) - A CloudControl Virtual Listener.
+* [ssl_offload_profile](resource_types/ssl_offload_profile.md) - An SSL-offload profile used by a Virtual Listener.
 * [ssl_domain_certificate](resource_types/ssl_domain_certificate.md) - An X.509 certificate (with private key) for SSL offload.
 * [ssl_certificate_chain](resource_types/ssl_certificate_chain.md) - An X.509 certificate chain for SSL offload.
 * [ddcloud_ip_address_reservation](resource_types/ip_address_reservation.md) - An IP address reservation on a CloudControl VLAN (experimental, for advanced usage scenarios only).

--- a/docs/datasource_types/pfx.md
+++ b/docs/datasource_types/pfx.md
@@ -1,0 +1,40 @@
+# ddcloud\_pfx
+
+The PFX (also known as PKCS12) format is used to store one or more certificates and / or private keys, protected by a password.
+
+The `ddcloud_pfx` data-source enables decoding of a `.pfx` file into PEM-format certificate and private key.
+
+**Note:** only the first certificate and private key in the `.pfx` file will be returned.
+
+## Example Usage
+
+```
+// Extract certificate and private key from test.pfx
+data "ddcloud_pfx" "server_cert" {
+    file        = "./server.pfx"
+    password    = "Hello123"
+}
+
+output "certificate_pem" {
+	value = "${data.ddcloud_pfx.server_cert.certificate}"
+}
+output "private_key_pem" {
+	value = "${data.ddcloud_pfx.server_cert.private_key}"
+}
+```
+
+Note that the `data.` prefix is required to reference data-source properties.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `file` - (Required) The path to the `.pfx` file.
+* `password` - (Required) The password used to decrypt the file's contents.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `certificate` - The first certificate found in the `.pfx` file, in PEM format.
+* `private_key` - The first private key found in the `.pfx` file, in PEM format.

--- a/docs/datasource_types/pfx.md
+++ b/docs/datasource_types/pfx.md
@@ -8,7 +8,7 @@ The `ddcloud_pfx` data-source enables decoding of a `.pfx` file into PEM-format 
 
 ## Example Usage
 
-```
+```hcl
 // Extract certificate and private key from test.pfx
 data "ddcloud_pfx" "server_cert" {
     file        = "./server.pfx"

--- a/docs/datasource_types/vlan.md
+++ b/docs/datasource_types/vlan.md
@@ -1,6 +1,6 @@
 # ddcloud\_vlan
 
-A VLAN isa virtual network.
+A VLAN is a virtual network.
 
 The `ddcloud_vlan` data-source enables lookup of a VLAN by name and network domain.
 

--- a/docs/resource_types/ssl_certificate_chain.md
+++ b/docs/resource_types/ssl_certificate_chain.md
@@ -1,0 +1,37 @@
+# ddcloud\_ssl\_certificate\_chain
+
+An X.509 certificate chain used for SSL offloading.
+
+## Example Usage
+
+```
+resource "ddcloud_ssl_certificate_chain" "my_chain" {
+  name          = "MyChain"
+  chain         = "${file("./chain.pem")}"
+
+  networkdomain = "${ddcloud_networkdomain.my_networkdomain.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `networkdomain` - (Required) The Id of the network domain in which the SSL domain certificate will be used for SSL offload.
+* `name` - (Required) A name for the certificate.
+* `description` - (Optional) A description for the certificate.
+* `chain` - (Required) The X.509 certificate chain (in PEM format).
+
+## Attribute Reference
+
+There are currently no additional attributes for `ddcloud_ssl_certificate_chain`.
+
+## Import
+
+Once declared in configuration, `ddcloud_ssl_certificate_chain` instances can be imported using their Id.
+
+For example:
+
+```bash
+$ terraform import ddcloud_ssl_certificate_chain.my_chain 87d42402-6bec-494d-b365-31971e415bc4
+```

--- a/docs/resource_types/ssl_certificate_chain.md
+++ b/docs/resource_types/ssl_certificate_chain.md
@@ -4,7 +4,7 @@ An X.509 certificate chain used for SSL offloading.
 
 ## Example Usage
 
-```
+```hcl
 resource "ddcloud_ssl_certificate_chain" "my_chain" {
   name          = "MyChain"
   chain         = "${file("./chain.pem")}"

--- a/docs/resource_types/ssl_domain_certificate.md
+++ b/docs/resource_types/ssl_domain_certificate.md
@@ -23,7 +23,8 @@ The following arguments are supported:
 * `description` - (Optional) A description for the certificate.
 * `certificate` - (Required) The X.509 certificate (in PEM format; use `ddcloud_pfx` data source if you need to use a certificate from a `.pfx` file).
 * `private_key` - (Required) The private key (in PEM format).  
-  **Note:** this value is not persisted in state data (providing Terraform does not crash during the initial `terraform apply`).
+  This value is not persisted in state data (providing Terraform does not crash during the initial `terraform apply`).  
+  **Note:** only RSA keys are supported by CloudControl.
 
 ## Attribute Reference
 

--- a/docs/resource_types/ssl_domain_certificate.md
+++ b/docs/resource_types/ssl_domain_certificate.md
@@ -4,7 +4,7 @@ An X.509 certificate (with private key) used for SSL offloading.
 
 ## Example Usage
 
-```
+```hcl
 resource "ddcloud_ssl_domain_certificate" "my_cert" {
   name        = "MyCertificate"
   certificate = "${file("./certificate.pem")}"

--- a/docs/resource_types/ssl_domain_certificate.md
+++ b/docs/resource_types/ssl_domain_certificate.md
@@ -1,0 +1,39 @@
+# ddcloud\_ssl\_domain\_certificate
+
+An X.509 certificate (with private key) used for SSL offloading.
+
+## Example Usage
+
+```
+resource "ddcloud_ssl_domain_certificate" "my_cert" {
+  name        = "MyCertificate"
+  certificate = "${file("./certificate.pem")}"
+  private_key = "${file("./private-key.pem")}"
+
+  networkdomain = "${ddcloud_networkdomain.my_networkdomain.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `networkdomain` - (Required) The Id of the network domain in which the SSL domain certificate will be used for SSL offload.
+* `name` - (Required) A name for the certificate.
+* `description` - (Optional) A description for the certificate.
+* `certificate` - (Required) The X.509 certificate (in PEM format, use `ddcloud_pfx` data source if you need to use a certificate from a `.pfx` file).
+* `private_key` - (Required) The private key (in PEM format).
+
+## Attribute Reference
+
+There are currently no additional attributes for `ddcloud_ssl_domain_certificate`.
+
+## Import
+
+Once declared in configuration, `ddcloud_ssl_domain_certificate` instances can be imported using their Id.
+
+For example:
+
+```bash
+$ terraform import ddcloud_ssl_domain_certificate.my_certificate 87d42402-6bec-494d-b365-31971e415bc4
+```

--- a/docs/resource_types/ssl_domain_certificate.md
+++ b/docs/resource_types/ssl_domain_certificate.md
@@ -21,7 +21,7 @@ The following arguments are supported:
 * `networkdomain` - (Required) The Id of the network domain in which the SSL domain certificate will be used for SSL offload.
 * `name` - (Required) A name for the certificate.
 * `description` - (Optional) A description for the certificate.
-* `certificate` - (Required) The X.509 certificate (in PEM format, use `ddcloud_pfx` data source if you need to use a certificate from a `.pfx` file).
+* `certificate` - (Required) The X.509 certificate (in PEM format; use `ddcloud_pfx` data source if you need to use a certificate from a `.pfx` file).
 * `private_key` - (Required) The private key (in PEM format).
 
 ## Attribute Reference

--- a/docs/resource_types/ssl_domain_certificate.md
+++ b/docs/resource_types/ssl_domain_certificate.md
@@ -22,7 +22,8 @@ The following arguments are supported:
 * `name` - (Required) A name for the certificate.
 * `description` - (Optional) A description for the certificate.
 * `certificate` - (Required) The X.509 certificate (in PEM format; use `ddcloud_pfx` data source if you need to use a certificate from a `.pfx` file).
-* `private_key` - (Required) The private key (in PEM format).
+* `private_key` - (Required) The private key (in PEM format).  
+  **Note:** this value is not persisted in state data (providing Terraform does not crash during the initial `terraform apply`).
 
 ## Attribute Reference
 

--- a/docs/resource_types/ssl_offload_profile.md
+++ b/docs/resource_types/ssl_offload_profile.md
@@ -27,7 +27,9 @@ The following arguments are supported:
 * `certificate` - (Required) The Id of the SSL domain certificate to use.
 * `chain` - (Optional) The Id of the SSL certificate chain (if any) to use.
 * `ciphers` - (Optional, Computed) SSL ciphers to use.  
-  If not specified, then CloudControl will a default selection of ciphers (see the CloudControl documentation for details).
+  If not specified, then CloudControl will a default selection of ciphers.  
+  Each data center location has a "default cipher" string that will be used if the cipher is not explicitly defined.  
+  The default cipher should work for most purposes.
 
 ## Attribute Reference
 

--- a/docs/resource_types/ssl_offload_profile.md
+++ b/docs/resource_types/ssl_offload_profile.md
@@ -1,0 +1,44 @@
+# ddcloud\_ssl\_offload\_profile
+
+A profile for SSL offloading used by a virtual listener.
+
+See the [CloudControl documentation](https://docs.mcp-services.net/display/CCD/Introduction+to+SSL+Offload%2C+including+SSL+Domain+Certificate%2C+SSL+Certificate+Chain%2C+and+SSL+Offload+Profiles) for more information about SSL offloading.
+
+## Example Usage
+
+```hcl
+resource "ddcloud_ssl_offload_profile" "my_offload_profile" {
+  name        = "MyOffloadProfile"
+  certificate = "${ddcloud_ssl_domain_certificate.my_certificate.id}"
+  chain       = "${ddcloud_ssl_certificate_chain.my_chain.id}"
+  ciphers     = "MEDIUM:HIGH:!EXPORT:!ADH:!MD5:!RC4:!SSLv2:!SSLv3:!ECDHE+AES-GCM:!ECDHE+AES:!ECDHE+3DES:!ECDHE_ECDSA:!ECDH_RSA:!ECDH_ECDSA:@SPEED"
+
+  networkdomain = "${data.ddcloud_networkdomain.primary.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `networkdomain` - (Required) The Id of the network domain in which the SSL domain certificate will be used for SSL offload.
+* `name` - (Required) A name for the certificate.
+* `description` - (Optional) A description for the certificate.
+* `certificate` - (Required) The Id of the SSL domain certificate to use.
+* `chain` - (Optional) The Id of the SSL certificate chain (if any) to use.
+* `ciphers` - (Optional, Computed) SSL ciphers to use.  
+  If not specified, then CloudControl will a default selection of ciphers (see the CloudControl documentation for details).
+
+## Attribute Reference
+
+There are currently no additional attributes for `ddcloud_ssl_offload_profile`.
+
+## Import
+
+Once declared in configuration, `ddcloud_ssl_offload_profile` instances can be imported using their Id.
+
+For example:
+
+```bash
+$ terraform import ddcloud_ssl_offload_profile.my_offload_profile 87d42402-6bec-494d-b365-31971e415bc4
+```

--- a/docs/resource_types/virtual_listener.md
+++ b/docs/resource_types/virtual_listener.md
@@ -52,10 +52,11 @@ The following arguments are supported:
 	  `ipv4` is required, and must be neither already be in use by a Node on the Network Domain nor fall within the IP space of a VLAN deployed on the Network Domain.
 * `port` - (Optional)
 * `enabled` - (Optional)
-* `connection_limit`
-* `connection_rate_limit`
-* `source_port_preservation`
-* `persistence_profile`
+* `ssl_offload_profile` - (Optional) The Id of an SSL-offload profile (if any) to assign to the virtual listener.
+* `connection_limit` (Optional) - The listener total connection limit.
+* `connection_rate_limit` (Optional) - The listener connection rate limit.
+* `source_port_preservation` (Optional) - Preserve source port information (if possible)?
+* `persistence_profile` (Optional) - The name of the persistence profile (if any) to use.
 * `irules`
 * `optimization_profiles`
 * `networkdomain` - (Required) The Id of the network domain in which the VIP pool is created.

--- a/docs/resource_types/virtual_listener.md
+++ b/docs/resource_types/virtual_listener.md
@@ -24,7 +24,8 @@ resource "ddcloud_virtual_listener" "test_virtual_listener" {
 
 The following arguments are supported:
 
-* `name` - (Required) A name for the virtual listener. **Note**: Changing this value will cause the listener to be destroyed and re-created.
+* `name` - (Required) A name for the virtual listener.  
+  **Note**: Changing this value will cause the listener to be destroyed and re-created.
 * `description` - (Optional) A description of the virtual listener.
 * `type` - (Optional) The listener type.  
   Must be one of:
@@ -63,4 +64,4 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-There are currently no additional attributes for `ddcloud_vip_pool`.
+There are currently no additional attributes for `ddcloud_virtual_listener`.


### PR DESCRIPTION
Implements 3 new resource types, and 1 new datasource:

* `ddcloud_ssl_offload_profile`: An SSL offload profile for use with Virtual Listeners.
* `ddcloud_ssl_domain_certificate`: An X.509 certificate (with private key) used for SSL offload.
* `ddcloud_ssl_certificate_chain`: An X.509 certificate chain used for SSL offload.
* `ddcloud_pfx`: Data source to extract a PEM-format certificate and private key from a `.pfx` file.

@calloes @kumarappanc - would you mind having a quick look to see if this will do what you want?

This closes #104.